### PR TITLE
Fix regex patter to validate `kubectl` version

### DIFF
--- a/src/commands/validate.js
+++ b/src/commands/validate.js
@@ -147,7 +147,7 @@ const validateKubectlVersion = () => {
   const result = utils.exec('kubectl version --client', true)
   if (result.stdout) {
     try {
-      const versionActual = semver.clean(result.stdout.match(/GitVersion:"v([^"]+)"/)[1])
+      const versionActual = semver.clean(result.stdout.match(/Client Version: v(\d+\.\d+\.\d+)/)[1])
       const versionRequired = semver.clean('1.23.0')
       if (semver.gte(versionActual, versionRequired))
         logSuccess(`kubectl is correct version [using=${versionActual}, required>=${versionRequired}]`)


### PR DESCRIPTION
This pull request primarily focuses on modifying the `validateKubectlVersion` function in the `src/commands/validate.js` file. The change made is to the regular expression used for parsing the version of `kubectl` from the command output. The new regular expression specifically targets the client version string in the output.

`GitVersion` doesn't correspond to the output of the `kubectl version --client` command. The current regular expression is not able to parse the client version string correctly. This change will ensure that the version string is correctly parsed and validated.

